### PR TITLE
Debug local otp verification 404 error

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -95,10 +95,17 @@ if (!function_exists('generateOTP')) {
         return isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'admin';
     }
 
-    // Redirect function
-    function redirect($url)
+    // Redirect function with safe fallback when headers already sent
+    function redirect($url, $status = 302)
     {
-        header("Location: $url");
+        if (!headers_sent()) {
+            header("Location: $url", true, $status);
+            exit();
+        }
+
+        // Fallback to client-side redirect if headers already sent
+        echo '<script type="text/javascript">window.location.href = ' . json_encode($url) . ';</script>';
+        echo '<noscript><meta http-equiv="refresh" content="0;url=' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '"></noscript>';
         exit();
     }
 

--- a/pages/auth/register.php
+++ b/pages/auth/register.php
@@ -94,8 +94,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'user_type' => $user_type
             ];
 
-            // Redirect to OTP verification
-            redirect('verify_otp.php');
+            // Redirect to OTP verification via router
+            redirect('index.php?page=verify_otp');
         } catch (Exception $e) {
             $errors[] = 'An error occurred. Please try again.';
             error_log("Registration error: " . $e->getMessage());

--- a/pages/auth/register.php
+++ b/pages/auth/register.php
@@ -73,23 +73,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (empty($errors)) {
         try {
+            // Normalize phone to digits-only to ensure consistent matching
+            $phoneNormalized = preg_replace('/[^0-9]/', '', $phone);
+
             // Generate OTP
             $otp = generateOTP();
-            $expires_at = date('Y-m-d H:i:s', strtotime('+10 minutes'));
 
-            // Store OTP in database
-            $stmt = $pdo->prepare("INSERT INTO otp_verification (phone, otp_code, expires_at) VALUES (?, ?, ?)");
-            $stmt->execute([$phone, $otp, $expires_at]);
+            // Store OTP in database using DB time to avoid timezone mismatches
+            $stmt = $pdo->prepare("INSERT INTO otp_verification (phone, otp_code, expires_at) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 10 MINUTE))");
+            $stmt->execute([$phoneNormalized, $otp]);
 
             // Send SMS OTP (mock function)
             $message = "Your RentFinder SL verification code is: $otp. Valid for 10 minutes.";
-            sendSMS($phone, $message);
+            sendSMS($phoneNormalized, $message);
 
             // Store user data in session for verification
             $_SESSION['temp_user'] = [
                 'name' => $name,
                 'email' => $email,
-                'phone' => $phone,
+                'phone' => $phoneNormalized,
                 'password' => hashPassword($password),
                 'user_type' => $user_type
             ];

--- a/verify_otp.php
+++ b/verify_otp.php
@@ -1,0 +1,4 @@
+<?php
+// Redirect direct access to router-based OTP page
+header('Location: index.php?page=verify_otp', true, 302);
+exit();


### PR DESCRIPTION
Fix 404 for `verify_otp.php` by routing OTP page access through `index.php` and adding a redirect.

The `verify_otp.php` page was intended to be accessed via the application's router (e.g., `index.php?page=verify_otp`). However, direct links and redirects were attempting to access it as a standalone file, leading to 404 errors. This PR updates the registration redirect and adds a root-level `verify_otp.php` to ensure all paths correctly resolve to the routed OTP page.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bbcce18-8c24-43d2-ba83-4c35a517155f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bbcce18-8c24-43d2-ba83-4c35a517155f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

