### PR TITLE
Fix headers already sent error

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -95,10 +95,14 @@ if (!function_exists('generateOTP')) {
         return isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'admin';
     }
 
-    // Redirect function with safe fallback when headers already sent
+    // Redirect function with buffering and safe fallbacks
     function redirect($url, $status = 302)
     {
+        // If output buffering is active, clear existing buffers before sending headers
         if (!headers_sent()) {
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
             header("Location: $url", true, $status);
             exit();
         }

--- a/index.php
+++ b/index.php
@@ -1,5 +1,11 @@
 <?php
 
+// Enable output buffering early to avoid "headers already sent" issues
+// This ensures redirects and header modifications can occur after includes
+if (function_exists('ob_start')) {
+    ob_start();
+}
+
 /**
  * RentFinder SL - Main Entry Point
  * Simple router for the application


### PR DESCRIPTION
Add output buffering at the application entry point and enhance the redirect function to prevent "headers already sent" warnings.

The "Cannot modify header information" warning occurred because output from included files (like `navbar_owner.php`) was sent before the `redirect()` function attempted to set a `Location` header. Starting output buffering early in `index.php` and clearing any accumulated buffers within `redirect()` ensures that headers can be sent successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-21fb2b09-c706-4b31-b9c3-73cd1024f166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21fb2b09-c706-4b31-b9c3-73cd1024f166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

